### PR TITLE
Add ibus-pinyin to Simplified Chinese packages.

### DIFF
--- a/usr/share/linuxmint/mintlocale/iminfo/locale/zh-hans.info
+++ b/usr/share/linuxmint/mintlocale/iminfo/locale/zh-hans.info
@@ -7,4 +7,5 @@ fonts-arphic-ukai
 fonts-arphic-uming
 fonts-noto-cjk
 ibus-sunpinyin
+ibus-pinyin
 ibus-table-wubi


### PR DESCRIPTION
ref: https://github.com/linuxmint/cinnamon/pull/12758

Discussion:

IM instructions are geared entirely for fcitx:
![image](https://github.com/user-attachments/assets/3eab8881-2a00-494c-92cd-cd19d5005745)

While the 'install' button will add support for both fcitx and ibus, the remaining instructions are fcitx-specific. Instead of these being modified 'if using Cinnamon use the layout applet, otherwise use the fcitx applet'... maybe Cinnamon-specific instructions or gladefile can be used when appropriate to keep the instructions (and translations) simple.

