### PR TITLE
Fix WM_CLASS for correct icon matching in docks and taskbars

### DIFF
--- a/usr/lib/linuxmint/mintlocale/im.py
+++ b/usr/lib/linuxmint/mintlocale/im.py
@@ -16,7 +16,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('AccountsService', '1.0')
 gi.require_version('XApp', '1.0')
-from gi.repository import Gtk, GObject, Gdk, XApp
+from gi.repository import Gtk, GObject, Gdk, XApp, GLib
 
 from ImConfig.ImConfig import ImConfig
 
@@ -27,7 +27,8 @@ locale.bindtextdomain(APP, LOCALE_DIR)
 gettext.bindtextdomain(APP, LOCALE_DIR)
 gettext.textdomain(APP)
 _ = gettext.gettext
-
+GLib.set_prgname("mintlocale-im")
+Gdk.set_program_class("Mintlocale-im")
 (IM_CHOICE, IM_NAME) = list(range(2))
 
 GObject.threads_init()

--- a/usr/share/applications/mintlocale-im.desktop
+++ b/usr/share/applications/mintlocale-im.desktop
@@ -154,3 +154,4 @@ Type=Application
 Encoding=UTF-8
 Categories=GNOME;GTK;Settings;DesktopSettings;XFCE;X-XFCE-SettingsDialog;X-XFCE-SystemSettings;
 StartupNotify=false
+StartupWMClass=mintlocale-im


### PR DESCRIPTION
When mintlocale-im is launched, its WM_CLASS is reported as "im.py"/"Im.py" 
because the entry point script is named im.py. This causes dock and taskbar 
applications to fail to match the window to its .desktop entry — "im" is too 
generic and matches nothing.

Changes:
- Added GLib to existing gi.repository import in im.py
- Added GLib.set_prgname("mintlocale-im") to correctly set the application name
- Added Gdk.set_program_class("Mintlocale-im") to correctly set the WM_CLASS
- Added StartupWMClass=mintlocale-im to mintlocale-im.desktop as a fallback 
  for dock/taskbar matching

Tested on Linux Mint 22.3 XFCE with xfce4-docklike-plugin.