### PR TITLE
install_remove: avoid redundant apt cache init on startup

### DIFF
--- a/usr/lib/linuxmint/mintlocale/install_remove.py
+++ b/usr/lib/linuxmint/mintlocale/install_remove.py
@@ -94,7 +94,7 @@ class MintLocale:
         ren.set_property('xpad', 10)
         self.treeview.append_column(column)
 
-        self.build_lang_list()
+        self.build_lang_list(refresh_cache=False)
 
         self.apt = aptkit.simpleclient.SimpleAPTClient(self.window)
 
@@ -132,8 +132,9 @@ class MintLocale:
 
         return (language_code, country_code, language_label)
 
-    def build_lang_list(self):
-        self.cache = apt_pkg.Cache(None)
+    def build_lang_list(self, refresh_cache=True):
+        if refresh_cache:
+            self.cache = apt_pkg.Cache(None)
 
         self.builder.get_object('button_install').set_sensitive(False)
         self.builder.get_object('button_remove').set_sensitive(False)


### PR DESCRIPTION
Fixes #92.

`MintLocale.__init__` builds `self.cache = apt_pkg.Cache(None)` at line 56, then immediately calls `build_lang_list()` which unconditionally rebuilds the cache at line 136. Each `apt_pkg.Cache(None)` call takes ~0.4 s, so the startup pays for it twice with no benefit.

**Fix:** add a `refresh_cache=True` parameter to `build_lang_list`. The `__init__` call passes `refresh_cache=False` to skip the redundant rebuild. The three post-operation calls (`on_install_finished`, `button_add_clicked`, `button_remove_clicked`) use the default `True` and still get a fresh cache after package changes.

**Result:** ~0.4 s faster startup (one `apt_pkg.Cache(None)` instead of two), matching the benchmark in #92.